### PR TITLE
WIP: Add fetchFromRecipe function

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -133,4 +133,32 @@ rec {
     in
       expandPackageFiles_ "";
 
+  fetchFromRecipe = recipe@{ fetcher, ... }:
+    let
+      path = split "/" recipe.repo;
+      owner = elemAt path 0;
+      repo = elemAt path 2;
+      rev = recipe.commit;
+      ref = recipe.branch;
+    in
+      if fetcher == "github"
+      then fetchFromGitHub {
+        inherit owner repo rev;
+      }
+      else if fetcher == "gitlab"
+      then fetchFromGitLab {
+        inherit owner repo rev;
+      }
+      else if fetcher == "git"
+      then fetchGit {
+        inherit (recipe) url;
+        inherit rev ref;
+      }
+      else if fetcher == "hg"
+      then fetchMercurial {
+        inherit (recipe) url;
+        inherit rev ref;
+      }
+      else throw ("Unsupported fetcher type: " + fetcher);
+
 }


### PR DESCRIPTION
This is intended for use in CI of an unpublished package on a centralised repository like MELPA (like melpazoid does) where source code of actual packages are not bundled in the CI context.

It should support all `:fetcher` types accepted by [MELPA](https://github.com/melpa/melpa/#recipe-format).

- [ ] Add a function to fetch a package source according to a recipe
- [ ] Add tests based on real recipes on MELPA