### PR TITLE
Add fetchTreeFromRecipe function

### DIFF
--- a/README.org
+++ b/README.org
@@ -102,6 +102,9 @@ The snapshot is stored in Nix, and the store path is returned.
     ...
   }
 #+end_src
+*** fetchTreeFromRecipe
+Like =fetchFromRecipe=, but uses =builtins.fetchTree= which has been added since Nix 2.4.
+Note that this still doesn't work in pure evaluation mode, unless you specify a commit in the recipe.
 *** expandPackageFiles
 =expandPackageFiles= function expands =:files= spec in a recipe under a given directory:
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -14,6 +14,9 @@ rec {
   fetchFromRecipe = pkgs.callPackage ./fetchFromRecipe.nix {
     inherit parseRecipe;
   };
+  fetchTreeFromRecipe = pkgs.callPackage ./fetchTreeFromRecipe.nix {
+    inherit parseRecipe;
+  };
   expandPackageFiles = pkgs.callPackage ./expandPackageFiles.nix {
     inherit defaultFilesSpec;
   };

--- a/lib/fetchTreeFromRecipe.nix
+++ b/lib/fetchTreeFromRecipe.nix
@@ -1,0 +1,40 @@
+# Fetch the source repository of a recipe using builtins.fetchTree
+#
+# Note that this works only Nix 2.4 or later.
+#
+# This doesn't work in pure evaluation.
+{ lib, parseRecipe }: recipe:
+with builtins;
+let
+  package = parseRecipe recipe;
+  inherit (package) fetcher;
+  path = split "/" package.repo;
+  owner = elemAt path 0;
+  repo = elemAt path 2;
+  repoAttrs = lib.filterAttrs (_: v: v != null) {
+    rev = package.commit;
+    ref = package.branch;
+  };
+in
+if fetcher == "github"
+then
+  fetchTree
+    ({
+      type = "github";
+      inherit owner repo;
+    } // repoAttrs)
+else if fetcher == "gitlab"
+then
+  fetchTree
+    ({
+      type = "gitlab";
+      inherit owner repo;
+    } // repoAttrs)
+else if fetcher == "git"
+then
+  fetchTree
+    ({
+      type = "git";
+      inherit (package) url;
+    } // repoAttrs)
+else throw "Unsupported fetcher type: ${fetcher}"

--- a/test/impure-checks.nix
+++ b/test/impure-checks.nix
@@ -5,6 +5,11 @@ let
     inherit (pkgs) lib;
     inherit (lib) fetchFromRecipe;
   };
+  result2 = import ./test-fetch-tree.nix {
+    inherit (pkgs) lib;
+    inherit (lib) fetchTreeFromRecipe;
+  };
 in
 assert (result == null);
+assert (result2 == null);
 pkgs.hello

--- a/test/pure-checks.nix
+++ b/test/pure-checks.nix
@@ -5,4 +5,5 @@
 }:
 assert (import ./test-cask.nix { inherit parseCask; } == null);
 assert (import ./test-recipe.nix { inherit parseRecipe expandPackageFiles; } == null);
+assert (import ./test-recipe.nix { inherit parseRecipe expandPackageFiles; } == null);
 hello

--- a/test/test-fetch-tree.nix
+++ b/test/test-fetch-tree.nix
@@ -1,0 +1,8 @@
+{ fetchTreeFromRecipe, lib }:
+with builtins;
+with lib;
+# Test only on public repositories
+assert (isStorePath (fetchTreeFromRecipe (readFile ./recipe1)));
+assert (isStorePath (fetchTreeFromRecipe (readFile ./recipe3)));
+assert (isStorePath (fetchTreeFromRecipe (readFile ./recipe4)));
+null


### PR DESCRIPTION
Nix 2.4 has added `builtins.fetchTree`, so I have added a variant of `fetchFromRecipe` that uses the new function.